### PR TITLE
Added a CircleCI job to validate contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           name: Check Contributor Agreement
           command: |
             CONTRIBUTOR=${CIRCLE_USERNAME:-CIRCLE_PR_USERNAME}
-            grep -r "^${CONTRIBUTOR}" CONTRIBUTORS.md
+            grep -r "^${CONTRIBUTOR}$" CONTRIBUTORS.md
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+# Configuration for CircleCI
+# See: https://circleci.com/docs/2.0/configuration-reference
+
+version: 2.1
+
+jobs:
+  check_contributor_agreement:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - checkout
+      - run:
+          name: Check Contributor Agreement
+          command: |
+            CONTRIBUTOR=${CIRCLE_USERNAME:-CIRCLE_PR_USERNAME}
+            grep -r "^${CONTRIBUTOR}" CONTRIBUTORS.md
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - check_contributor_agreement

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@ Adding your GitHub username to this list confirms that you agree to the terms of
 the Contributor License Agreement.
 
 simpleigh
+drichards2

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+Adding your GitHub username to this list confirms that you agree to the terms of
+the Contributor License Agreement.
+
+simpleigh


### PR DESCRIPTION
## Why?

All contributors should sign our Contributor License Agreement to confirm they agree to donate their code to the HawkEar project. We'd prefer to enforce this automatically.

## What?

* Add `CONTRIBUTORS.md` file. People "sign" the agreement by adding their GitHub username to this file.
* Add CircleCI job to check a PR's author is in the contributors file.